### PR TITLE
Fixes #152. In the manual crawl API spaces in URLs are correctly handled

### DIFF
--- a/src/main/java/com/jaeksoft/searchlib/webservice/CommonResult.java
+++ b/src/main/java/com/jaeksoft/searchlib/webservice/CommonResult.java
@@ -67,6 +67,8 @@ public class CommonResult implements InfoCallback {
 	}
 
 	public CommonResult addDetail(String key, Object value) {
+		if (value == null)
+			return this;
 		if (details == null)
 			details = new TreeMap<String, String>();
 		details.put(key, value.toString());

--- a/src/main/java/com/jaeksoft/searchlib/webservice/crawler/webcrawler/RestWebCrawler.java
+++ b/src/main/java/com/jaeksoft/searchlib/webservice/crawler/webcrawler/RestWebCrawler.java
@@ -23,12 +23,13 @@
  **/
 package com.jaeksoft.searchlib.webservice.crawler.webcrawler;
 
-import java.net.URL;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -118,7 +119,14 @@ public interface RestWebCrawler {
 	@Path("/crawl")
 	public CommonResult crawl(@PathParam("index_name") String use,
 			@QueryParam("login") String login, @QueryParam("key") String key,
-			@QueryParam("url") URL url);
+			@QueryParam("url") String url);
+
+	@POST
+	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+	@Path("/crawl")
+	public CommonResult crawlPost(@PathParam("index_name") String use,
+			@QueryParam("login") String login, @QueryParam("key") String key,
+			@FormParam("url") String url);
 
 	@PUT
 	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })

--- a/src/main/java/com/jaeksoft/searchlib/webservice/crawler/webcrawler/SoapWebCrawler.java
+++ b/src/main/java/com/jaeksoft/searchlib/webservice/crawler/webcrawler/SoapWebCrawler.java
@@ -23,7 +23,6 @@
  **/
 package com.jaeksoft.searchlib.webservice.crawler.webcrawler;
 
-import java.net.URL;
 import java.util.List;
 
 import javax.jws.WebParam;
@@ -80,13 +79,16 @@ public interface SoapWebCrawler {
 
 	public CommonResult captureScreenshot(@WebParam(name = "use") String use,
 			@WebParam(name = "login") String login,
-			@WebParam(name = "key") String key, @WebParam(name = "url") URL url);
+			@WebParam(name = "key") String key,
+			@WebParam(name = "url") String url);
 
 	public CommonResult checkScreenshot(@WebParam(name = "use") String use,
 			@WebParam(name = "login") String login,
-			@WebParam(name = "key") String key, @WebParam(name = "url") URL url);
+			@WebParam(name = "key") String key,
+			@WebParam(name = "url") String url);
 
 	public CommonResult crawl(@WebParam(name = "use") String use,
 			@WebParam(name = "login") String login,
-			@WebParam(name = "key") String key, @WebParam(name = "url") URL url);
+			@WebParam(name = "key") String key,
+			@WebParam(name = "url") String url);
 }


### PR DESCRIPTION
We also provide details in the JSON result

``` json
{
    "successful": true,
    "info": "Result: Gone - Not parsed - Not indexed",
    "details": {
        "ContentBaseType": "text/html",
        "ContentLength": "-1",
        "ContentTypeCharset": "UTF-8",
        "FetchStatus": "Gone",
        "HttpResponseCode": "404",
        "IndexStatus": "Not indexed",
        "ParserStatus": "Not parsed",
        "RobotsTxtStatus": "Allow",
        "URL": "http://www.open-search-server.com/test%20test/"
    }
}
```
