### PR TITLE
Fix #642.

### DIFF
--- a/src/main/java/com/jaeksoft/searchlib/ClientCatalog.java
+++ b/src/main/java/com/jaeksoft/searchlib/ClientCatalog.java
@@ -485,6 +485,17 @@ public class ClientCatalog {
 		FileUtils.deleteDirectory(tempDir);
 	}
 
+	public static void receive_abort(Client client) throws IOException {
+		File tempDir = getTempReceiveDir(client);
+		File trashDir = getTrashReceiveDir(client);
+		synchronized (ClientCatalog.class) {
+			if (tempDir.exists())
+				FileUtils.deleteDirectory(tempDir);
+			if (trashDir.exists())
+				FileUtils.deleteDirectory(trashDir);
+		}
+	}
+
 	public static final void receive_dir(Client client, String filePath)
 			throws IOException {
 		File rootDir = getTempReceiveDir(client);

--- a/src/main/java/com/jaeksoft/searchlib/config/Config.java
+++ b/src/main/java/com/jaeksoft/searchlib/config/Config.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.InvalidPropertiesFormatException;
@@ -192,7 +191,7 @@ public abstract class Config implements ThreadFactory {
 
 	protected final File indexDir;
 
-	protected final SimpleLock replicationLock = new SimpleLock();
+	private final SimpleLock replicationLock = new SimpleLock();
 
 	private ReplicationList replicationList = null;
 
@@ -1770,10 +1769,6 @@ public abstract class Config implements ThreadFactory {
 		replicationLock.rl.lock();
 		try {
 			replicationThread.push();
-		} catch (MalformedURLException e) {
-			throw new SearchLibException(e);
-		} catch (URISyntaxException e) {
-			throw new SearchLibException(e);
 		} finally {
 			replicationLock.rl.unlock();
 		}

--- a/src/main/java/com/jaeksoft/searchlib/replication/ReplicationThread.java
+++ b/src/main/java/com/jaeksoft/searchlib/replication/ReplicationThread.java
@@ -26,8 +26,6 @@ package com.jaeksoft.searchlib.replication;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,6 +65,8 @@ public class ReplicationThread extends ThreadAbstract<ReplicationThread>
 
 	private final ReplicationType replicationType;
 
+	private final long initVersion;
+
 	protected ReplicationThread(Client client,
 			ReplicationMaster replicationMaster,
 			ReplicationItem replicationItem, InfoCallback infoCallback)
@@ -75,6 +75,7 @@ public class ReplicationThread extends ThreadAbstract<ReplicationThread>
 		this.sourceDirectory = replicationItem.getDirectory(client);
 		this.replicationType = replicationItem.getReplicationType();
 		this.client = client;
+		initVersion = client.getIndex().getVersion();
 		totalSize = 0;
 		filesSent = 0;
 		checkedSize = 0;
@@ -88,7 +89,7 @@ public class ReplicationThread extends ThreadAbstract<ReplicationThread>
 		try {
 			if (checkedSize == 0 || totalSize == 0)
 				return 0;
-			int p = (int) (checkedSize / totalSize) * 100;
+			int p = (int) ((checkedSize / totalSize) * 100);
 			return p;
 		} finally {
 			rwl.r.unlock();
@@ -153,20 +154,29 @@ public class ReplicationThread extends ThreadAbstract<ReplicationThread>
 			setInfo("Completed");
 	}
 
-	public void push() throws SearchLibException, MalformedURLException,
-			URISyntaxException {
+	public void push() throws SearchLibException {
 		ReplicationItem replicationItem = getReplicationItem();
-		setTotalSize(new LastModifiedAndSize(sourceDirectory, false).getSize());
-		addCheckedSize(sourceDirectory.length());
-		PushServlet.call_init(getReplicationItem());
-		new RecursiveDirectoryBrowser(sourceDirectory, this);
-		switch (replicationItem.getReplicationType().getFinalMode()) {
-		case MERGE:
-			PushServlet.call_merge(replicationItem);
-			break;
-		case SWITCH:
-			PushServlet.call_switch(replicationItem);
-			break;
+		try {
+			setTotalSize(new LastModifiedAndSize(sourceDirectory, false)
+					.getSize());
+			addCheckedSize(sourceDirectory.length());
+			PushServlet.call_init(getReplicationItem());
+			new RecursiveDirectoryBrowser(sourceDirectory, this);
+			checkVersion();
+			switch (replicationItem.getReplicationType().getFinalMode()) {
+			case MERGE:
+				PushServlet.call_merge(replicationItem);
+				break;
+			case SWITCH:
+				PushServlet.call_switch(replicationItem);
+				break;
+			}
+		} catch (Throwable t) {
+			PushServlet.call_abort(replicationItem);
+			if (t instanceof SearchLibException)
+				throw (SearchLibException) t;
+			else
+				throw new SearchLibException(t);
 		}
 	}
 
@@ -213,9 +223,16 @@ public class ReplicationThread extends ThreadAbstract<ReplicationThread>
 				+ FileUtils.byteCountToDisplaySize(getBytesSent()) + " sent";
 	}
 
+	private void checkVersion() throws SearchLibException {
+		if (initVersion != client.getIndex().getVersion())
+			throw new SearchLibException(
+					"Replication process aborted. The index has changed.");
+	}
+
 	@Override
 	public void file(File file) throws SearchLibException {
 		try {
+			checkVersion();
 			ReplicationItem replicationItem = getReplicationItem();
 			long length = file.length();
 			if (file.isFile()) {

--- a/src/main/java/com/jaeksoft/searchlib/web/PushServlet.java
+++ b/src/main/java/com/jaeksoft/searchlib/web/PushServlet.java
@@ -1,7 +1,7 @@
 /**   
  * License Agreement for OpenSearchServer
  *
- * Copyright (C) 2008-2013 Emmanuel Keller / Jaeksoft
+ * Copyright (C) 2008-2014 Emmanuel Keller / Jaeksoft
  * 
  * http://www.open-search-server.com
  * 
@@ -89,6 +89,14 @@ public class PushServlet extends AbstractServlet {
 						XML_CALL_KEY_STATUS_OK);
 				return;
 			}
+			if (CALL_XML_CMD_ABORT.equals(cmd)) {
+				transaction
+						.addXmlResponse(CALL_XML_KEY_CMD, CALL_XML_CMD_ABORT);
+				ClientCatalog.receive_abort(client);
+				transaction.addXmlResponse(XML_CALL_KEY_STATUS,
+						XML_CALL_KEY_STATUS_OK);
+				return;
+			}
 			String filePath = transaction
 					.getParameterString(CALL_XML_CMD_FILEPATH);
 			Long lastModified = transaction
@@ -139,6 +147,7 @@ public class PushServlet extends AbstractServlet {
 	private final static String CALL_XML_CMD_MERGE = "merge";
 	private final static String CALL_XML_CMD_EXISTS = "exists";
 	private final static String CALL_XML_CMD_FILEPATH = "filePath";
+	private final static String CALL_XML_CMD_ABORT = "abort";
 
 	private static String getPushTargetUrl(Client client,
 			ReplicationItem replicationItem, String cmd, File sourceFile)
@@ -211,6 +220,11 @@ public class PushServlet extends AbstractServlet {
 	public static void call_merge(ReplicationItem replicationItem)
 			throws SearchLibException {
 		call(replicationItem, CALL_XML_CMD_MERGE);
+	}
+
+	public static void call_abort(ReplicationItem replicationItem)
+			throws SearchLibException {
+		call(replicationItem, CALL_XML_CMD_ABORT);
 	}
 
 	public static boolean call_file_exist(Client client,


### PR DESCRIPTION
If an index is updated during a replication, the replication process is
aborted.
