### PR TITLE
Fix #739. HTMLCleaner does not preserve the lang attribute on DOM

### DIFF
--- a/src/main/java/com/jaeksoft/searchlib/parser/htmlParser/HtmlCleanerParser.java
+++ b/src/main/java/com/jaeksoft/searchlib/parser/htmlParser/HtmlCleanerParser.java
@@ -80,6 +80,9 @@ public class HtmlCleanerParser extends HtmlDocumentProvider {
 	private DomHtmlNode getDomHtmlNode() throws ParserConfigurationException {
 		Document document = new DomSerializer(cleaner.getProperties(), true)
 				.createDOM(rootTagNode);
+		String lang = rootTagNode.getAttributeByName("lang");
+		if (lang != null)
+			document.getDocumentElement().setAttribute("lang", lang);
 		return new DomHtmlNode(document);
 	}
 


### PR DESCRIPTION
serialization.
