### PR TITLE
Fix org.zkoss.zel.ELException: Error writing 'crawlScope' on type com.ja...

### DIFF
--- a/src/main/java/com/jaeksoft/searchlib/crawler/cache/CrawlCacheManager.java
+++ b/src/main/java/com/jaeksoft/searchlib/crawler/cache/CrawlCacheManager.java
@@ -73,9 +73,8 @@ public class CrawlCacheManager implements Closeable {
 
 	private File propFile;
 
-	public CrawlCacheManager(File confDir)
-			throws InvalidPropertiesFormatException, IOException,
-			InstantiationException, IllegalAccessException {
+	public CrawlCacheManager(File confDir) throws InstantiationException,
+			IllegalAccessException, IOException {
 		crawlCache = null;
 		propFile = new File(confDir, CRAWLCACHE_PROPERTY_FILE);
 		Properties properties = PropertiesUtils.loadFromXml(propFile);
@@ -90,7 +89,11 @@ public class CrawlCacheManager implements Closeable {
 		configuration = properties
 				.getProperty(CRAWCACHE_PROPERTY_CONFIGURATION);
 		crawlCache = crawlCacheProvider.getNewInstance();
-		setEnabled(enabled);
+		try {
+			setEnabled(enabled);
+		} catch (IOException e) {
+			Logging.warn("Enabling the crawl cache failed.", e);
+		}
 	}
 
 	private static CrawlCacheManager INSTANCE = null;


### PR DESCRIPTION
...eksoft.searchlib.web.controller.runtime.CrawlCacheComposer

> > com.jaeksoft.searchlib.SearchLibException: java.io.IOException: The folder /var/local/crawl-cache/... does not exists
