### PR TITLE
Updated download links in documentation

### DIFF
--- a/src/doc/en/documentation/api_v2/searching_using_fields/search.md
+++ b/src/doc/en/documentation/api_v2/searching_using_fields/search.md
@@ -157,7 +157,7 @@ The search result has been returned.
                     {
                         "fieldName": "url",
                         "values": [
-                            "http://www.open-search-server.com/download/"
+                            "https://cloud.opensearchserver.com/opensearchserver#download"
                         ]
                     }
                 ],

--- a/src/doc/en/documentation/api_v2/searching_using_fields/template_search.md
+++ b/src/doc/en/documentation/api_v2/searching_using_fields/template_search.md
@@ -118,7 +118,7 @@ The search result has been returned.
                     {
                         "fieldName": "url",
                         "values": [
-                            "http://www.open-search-server.com/download/"
+                            "https://cloud.opensearchserver.com/opensearchserver#download"
                         ]
                     }
                 ],

--- a/src/doc/en/documentation/api_v2/searching_using_patterns/template_search.md
+++ b/src/doc/en/documentation/api_v2/searching_using_patterns/template_search.md
@@ -125,7 +125,7 @@ The search result has been returned.
                     {
                         "fieldName": "url",
                         "values": [
-                            "http://www.open-search-server.com/download/"
+                            "https://cloud.opensearchserver.com/opensearchserver#download"
                         ]
                     }
                 ],

--- a/src/doc/en/documentation/installation/debian.md
+++ b/src/doc/en/documentation/installation/debian.md
@@ -7,7 +7,7 @@ The Short Version should be sufficient ; if not use the More Detailed Version.
 ## Short version
 
 - Make sure you have a Java 7 Virtual Machine or newer correctly installed
-- Download the latest stable build [opensearchserver-X.X.X-bXXX.deb](http://www.open-search-server.com/download/  "Download")
+- Download the latest stable build [opensearchserver-X.X.X-bXXX.deb](https://cloud.opensearchserver.com/opensearchserver#download  "Download")
 - Install it with the following command: `dpkg -i opensearchserver-X.X.X-bXXX.deb`
 - Start the service using: `service opensearchserver start`
 - Open your favorite browser with the URL [http://yourserver:9090](http://yourserver:9090) (replace **yourserver** by **localhost** if it's running on your own machine)
@@ -36,7 +36,7 @@ To install OpenJDK just use your favorite package manager:
 
 ### Installing OpenSearchServer
 
-We recommend that you always get the latest version of OSS on [SourceForge](http://www.open-search-server.com/download/ "Download").
+We recommend that you always get the latest version of OSS on [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Please download the **opensearchserver-X.X.X-bXXX.deb** package for Debian, then install it as in the example below:
 

--- a/src/doc/en/documentation/installation/linux.md
+++ b/src/doc/en/documentation/installation/linux.md
@@ -7,7 +7,7 @@ The Short Version should be sufficient ; if not use the More Detailed Version.
 ## Short version
 
 - Make sure you have a Java 6 Virtual Machine or newer correctly installed
-- Download the latest stable build [tar.gz](http://www.open-search-server.com/download/  "Download")
+- Download the latest stable build [tar.gz](https://cloud.opensearchserver.com/opensearchserver#download  "Download")
 - Deflate it and run start.sh, which you'll find within the OSS folder
 - Open your favorite browser with the URL [http://yourserver:9090](http://yourserver:9090) (replace **yourserver** by **localhost** if it's running on your own machine)
 - Enjoy discovering OpenSearchServer
@@ -41,7 +41,7 @@ To install OpenJDK just follow the instructions provided at [the openJDK site](
 
 ### Downloading OpenSearchServer
 
-We recommend that you always get the latest version of OSS on [SourceForge](http://www.open-search-server.com/download/ "Download").
+We recommend that you always get the latest version of OSS on [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Please download the **tar.gz** package for Linux/BSD, then deflate it as in the example below:
 

--- a/src/doc/en/documentation/installation/mac_os_x.md
+++ b/src/doc/en/documentation/installation/mac_os_x.md
@@ -26,7 +26,7 @@ Check whether your Java version is 6 or newer:
 
 ### Downloading OSS
 
-We recommend that you always get the latest version of OSS on [SourceForge](http://www.open-search-server.com/download/ "Download").
+We recommend that you always get the latest version of OSS on [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Please download the **tar.gz** or **zip** package, then deflate it as in the example below:
 

--- a/src/doc/en/documentation/installation/windows.md
+++ b/src/doc/en/documentation/installation/windows.md
@@ -3,7 +3,7 @@
 ## Short Version
 
 - Make sure you have JAVA 6 or newer correctly installed
-- Download the latest stable build [zip](http://www.open-search-server.com/download/ "Download")
+- Download the latest stable build [zip](https://cloud.opensearchserver.com/opensearchserver#download "Download")
 - Deflate it and run **start.bat**, which you'll find within the OpenSearchServer folder
 - Open your favorite browser with the url [http://yourserver:9090](http://yourserver:9090) (your server being **localhost** if it's running on your local machine)
 - Enjoy discovering OpenSearchServer
@@ -22,7 +22,7 @@ In the latter two cases, you will be presented with a **Free Java Download** bu
 
 ### Downloading OpenSearchServer
 
-We recommend that you always get the latest version of OSS on [SourceForge](http://www.open-search-server.com/download/ "Download").
+We recommend that you always get the latest version of OSS on [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Please download the **ZIP** package for Windows and unzip it on your disk.
 

--- a/src/doc/fr/documentation/installation%7CGuide_d'installation%7C1/linux%7Cmise_en_oeuvre_sur_Linux%7C2.md
+++ b/src/doc/fr/documentation/installation%7CGuide_d'installation%7C1/linux%7Cmise_en_oeuvre_sur_Linux%7C2.md
@@ -5,7 +5,7 @@ La version courte ci-dessous est habituellement suffisante ; en cas de souci uti
 ## Version courte
 
 - Assurez-vous d'avoir une Java Virtual Machine dans sa version 6 ou plus récente
-- Téléchargez notre dernière version stable sur [tar.gz](http://www.open-search-server.com/download/  "Download")
+- Téléchargez notre dernière version stable sur [tar.gz](https://cloud.opensearchserver.com/opensearchserver#download  "Download")
 - Décompressez-la, puis lancez le start.sh qui se trouve dans le dossier OSS
 - Via votre navigateur préféré, ouvrez l'URL [http://votreserveur:9090](http://votreserveurr:9090) (remplacez **yourserver** par **localhost** si OSS tourne sur votre machine locale)
 - Bonne découverte d'OpenSearchServer !
@@ -37,7 +37,7 @@ Pour ce faire, suivez juste les instructions sur [le site openJDK](http://openj
 
 ### Télécharger OpenSearchServer
 
-Nous recommendons vivement de toujours utiliser la dernière version d'OSS disponible sur [SourceForge](http://www.open-search-server.com/download/ "Download").
+Nous recommendons vivement de toujours utiliser la dernière version d'OSS disponible sur [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Téléchargez le package **tar.gz** pour Linux/BSD, puis décompressez-le comme suit :
 

--- a/src/doc/fr/documentation/installation%7CGuide_d'installation%7C1/mac_os_x%7Cmise_en_oeuvre_sur_MacOS_X%7C3.md
+++ b/src/doc/fr/documentation/installation%7CGuide_d'installation%7C1/mac_os_x%7Cmise_en_oeuvre_sur_MacOS_X%7C3.md
@@ -3,7 +3,7 @@ Installer OpenSearchServer sur un Mac est très simple. La version courte ci-des
 ## Version courte
 
 - Assurez-vous d'avoir une Java Virtual Machine dans sa version 6 ou plus récente
-- Téléchargez notre dernière version stable sur [tar.gz](http://www.open-search-server.com/download/  "Download")
+- Téléchargez notre dernière version stable sur [tar.gz](https://cloud.opensearchserver.com/opensearchserver#download  "Download")
 - Décompressez-la, puis lancez le start.sh qui se trouve dans le dossier OSS
 - Via votre navigateur préféré, ouvrez l'URL [http://votreserveur:9090](http://votreserveurr:9090) (remplacez **votreserveur** par **localhost** si OSS tourne sur votre machine locale)
 - Bonne découverte d'OpenSearchServer !
@@ -22,7 +22,7 @@ Lancez un terminal et tapez :
 
 ### Télécharger OSS
 
-Nous recommendons vivement de toujours utiliser la dernière version d'OSS disponible sur [SourceForge](http://www.open-search-server.com/download/ "Download").
+Nous recommendons vivement de toujours utiliser la dernière version d'OSS disponible sur [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Téléchargez le package **tar.gz** pour Linux/BSD, puis décompressez-le comme suit :
 

--- a/src/doc/fr/documentation/installation%7CGuide_d'installation%7C1/windows%7Crmise_en_oeuvre_sur_Windows%7C4.md
+++ b/src/doc/fr/documentation/installation%7CGuide_d'installation%7C1/windows%7Crmise_en_oeuvre_sur_Windows%7C4.md
@@ -1,7 +1,7 @@
 ## Version courte
 
 - Assurez-vous d'avoir JAVA 6 ou plus récent
-- Téléchargez la dernière version stable [zip](http://www.open-search-server.com/download/ "Download")
+- Téléchargez la dernière version stable [zip](https://cloud.opensearchserver.com/opensearchserver#download "Download")
 - Décompressez-la et lancez **start.bat**, qui se trouve dans le dossier OpenSearchServer
 - Via un navigateur web ouvrez l'URL [http://votreserveur:9090](http://votreserveur:9090) (votre serveur étant **localhost** si jamais vous exécutez OSS en local)
 - Bonne découverte d'OpenSearchServer !
@@ -20,7 +20,7 @@ Dans les deux cas, la page vous propose un bouton pour télécharger gratuitemen
 
 ### Télécharger OpenSearchServer
 
-Nous recommendons vivement de toujours utiliser la dernière version d'OSS disponible sur [SourceForge](http://www.open-search-server.com/download/ "Download").
+Nous recommendons vivement de toujours utiliser la dernière version d'OSS disponible sur [SourceForge](https://cloud.opensearchserver.com/opensearchserver#download "Download").
 
 Téléchargez le package **ZIP** pour Windows et dézipez le sur votre disque.
 


### PR DESCRIPTION
Your current links http://www.open-search-server.com/download/ give a 404. I found out via google that this was the new location: https://cloud.opensearchserver.com/opensearchserver#download.

Updated all `.md` files to reflect this.